### PR TITLE
Add scripts to export and compare docling-layout-heron in ONNX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.onnx
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# ds4sd-docling-layout-heron-onnx
+# ds4sd-docling-layout-heron ONNX
+
+Utilities to export the [`ds4sd/docling-layout-heron`](https://huggingface.co/ds4sd/docling-layout-heron) object detection model to ONNX and compare it against the original PyTorch implementation.
+
+## Usage
+
+1. **Convert the model**
+   ```bash
+   python convert_to_onnx.py
+   ```
+   This downloads the model and produces four variants:
+   - `docling_layout_heron.onnx` – simplified full precision reference
+   - `docling_layout_heron_quant.onnx` – MatMul weights dynamically quantized to int8
+   - `docling_layout_heron_fp16.onnx` – most weights converted to float16 while keeping MatMul ops in float32
+   - `docling_layout_heron_static.onnx` – statically quantized int8 model using random calibration data
+
+2. **Run a quick comparison**
+   ```bash
+    python compare_models.py
+    ```
+    The script generates a random 640x640 image, runs it through PyTorch and the ONNX models, and prints the maximum absolute differences together with average inference times.
+
+   A sample CPU run produced the following results on random 640×640 input:
+
+   | model | size (MB) | time (ms) | max rel diff logits | max rel diff boxes |
+   |-------|---------:|----------:|--------------------:|-------------------:|
+   | PyTorch | n/a | 1445.89 | – | – |
+   | ONNX | 164.2 | 807.15 | – | – |
+   | Dynamic Quantized ONNX | 141.8 | 753.66 | 36.93% | 94.77% |
+   | Float16 ONNX | 97.4 | 1070.32 | 33.95% | 96.04% |
+   | Static Quantized ONNX | 42.8 | 659.89 | 72.71% | 96.09% |
+
+   Static quantization yields the smallest file but shows large divergence on the random test image.
+
+> The generated `.onnx` files are ignored by git and are not part of the repository.

--- a/compare_models.py
+++ b/compare_models.py
@@ -1,0 +1,76 @@
+import os
+import time
+
+import numpy as np
+import onnxruntime as ort
+import torch
+from transformers import AutoModelForObjectDetection
+
+
+def generate_input(batch_size: int = 1) -> torch.Tensor:
+    """Generate a random image tensor in the expected format."""
+    return torch.randn(batch_size, 3, 640, 640)
+
+
+def run_torch(model, x: torch.Tensor, runs: int = 5):
+    with torch.no_grad():
+        start = time.perf_counter()
+        for _ in range(runs):
+            out = model(x)[0:2]
+        elapsed = (time.perf_counter() - start) / runs
+    return out, elapsed
+
+
+def run_onnx(session: ort.InferenceSession, x: torch.Tensor, runs: int = 5):
+    start = time.perf_counter()
+    for _ in range(runs):
+        out = session.run(None, {"pixel_values": x.numpy()})
+    elapsed = (time.perf_counter() - start) / runs
+    return out, elapsed
+
+
+def main():
+    x = generate_input()
+    model = AutoModelForObjectDetection.from_pretrained("ds4sd/docling-layout-heron")
+    model.eval()
+    model.config.return_dict = False
+    pt_out, pt_time = run_torch(model, x)
+    print(f"PyTorch average time: {pt_time*1000:.2f} ms")
+
+    # Baseline ONNX
+    sess = ort.InferenceSession("docling_layout_heron.onnx", providers=["CPUExecutionProvider"])
+    onnx_out, onnx_time = run_onnx(sess, x)
+    base_size = os.path.getsize("docling_layout_heron.onnx") / 1024**2
+    print(f"ONNX size: {base_size:.1f} MB, time: {onnx_time*1000:.2f} ms")
+    print("Max abs diff logits vs PyTorch:", np.max(np.abs(pt_out[0].numpy() - onnx_out[0])))
+    print("Max abs diff boxes vs PyTorch:", np.max(np.abs(pt_out[1].numpy() - onnx_out[1])))
+
+    def report_variant(name: str, path: str):
+        if not os.path.exists(path):
+            print(f"{name} model not found: {path}")
+            return
+        try:
+            sess_v = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+        except Exception as e:
+            print(f"{name} load failed: {e}")
+            return
+        out_v, t_v = run_onnx(sess_v, x)
+        size_v = os.path.getsize(path) / 1024**2
+        rel_logits = np.max(np.abs(onnx_out[0] - out_v[0])) / np.maximum(
+            np.max(np.abs(onnx_out[0])), 1e-9
+        )
+        rel_boxes = np.max(np.abs(onnx_out[1] - out_v[1])) / np.maximum(
+            np.max(np.abs(onnx_out[1])), 1e-9
+        )
+        print(
+            f"{name} size: {size_v:.1f} MB, time: {t_v*1000:.2f} ms, "
+            f"max rel diff logits: {rel_logits*100:.2f}%, boxes: {rel_boxes*100:.2f}%"
+        )
+
+    report_variant("Dynamic Quantized ONNX", "docling_layout_heron_quant.onnx")
+    report_variant("Float16 ONNX", "docling_layout_heron_fp16.onnx")
+    report_variant("Static Quantized ONNX", "docling_layout_heron_static.onnx")
+
+
+if __name__ == "__main__":
+    main()

--- a/convert_to_onnx.py
+++ b/convert_to_onnx.py
@@ -1,0 +1,132 @@
+import os
+
+import numpy as np
+import onnx
+import torch
+from onnxruntime.quantization import (
+    CalibrationDataReader,
+    QuantFormat,
+    QuantType,
+    quantize_dynamic,
+    quantize_static,
+)
+from onnxruntime.transformers.float16 import convert_float_to_float16
+from transformers import AutoModelForObjectDetection
+
+
+class RandomDataReader(CalibrationDataReader):
+    """Supply random images for static quantization calibration."""
+
+    def __init__(self, num_batches: int = 5):
+        self.num_batches = num_batches
+        self.batch = 0
+
+    def get_next(self):
+        if self.batch >= self.num_batches:
+            return None
+        self.batch += 1
+        data = np.random.randn(1, 3, 640, 640).astype(np.float32)
+        return {"pixel_values": data}
+
+    def rewind(self):
+        self.batch = 0
+
+
+def convert(
+    output_path: str = "docling_layout_heron.onnx",
+    quantized_path: str = "docling_layout_heron_quant.onnx",
+    fp16_path: str = "docling_layout_heron_fp16.onnx",
+    static_quant_path: str = "docling_layout_heron_static.onnx",
+) -> None:
+    """Export the ds4sd/docling-layout-heron model to ONNX and produce
+    smaller variants.
+
+    Besides the full precision model, a dynamically quantized version
+    (``int8`` MatMul weights), a float16 converted model and a statically
+    quantized model are created. Static quantization uses random images for
+    calibration and quantizes both weights and activations to ``int8``.
+
+    All models expect an input tensor ``pixel_values`` of shape
+    ``(batch, 3, 640, 640)`` and return ``logits`` and ``pred_boxes``.
+    """
+
+    model = AutoModelForObjectDetection.from_pretrained("ds4sd/docling-layout-heron")
+    model.eval()
+    model.config.return_dict = False
+
+    dummy = torch.randn(1, 3, 640, 640)
+
+    torch.onnx.export(
+        model,
+        (dummy,),
+        output_path,
+        input_names=["pixel_values"],
+        output_names=["logits", "pred_boxes"],
+        opset_version=17,
+        dynamic_axes={
+            "pixel_values": {0: "batch"},
+            "logits": {0: "batch"},
+            "pred_boxes": {0: "batch"},
+        },
+    )
+    size_mb = os.path.getsize(output_path) / 1024**2
+    print(f"Saved ONNX model to {output_path} ({size_mb:.1f} MB)")
+
+    # Simplify the graph to fold constants and remove unused nodes
+    try:
+        import onnxsim
+
+        model_simp, check = onnxsim.simplify(output_path)
+        if check:
+            onnx.save(model_simp, output_path)
+            size_mb = os.path.getsize(output_path) / 1024**2
+            print(f"Simplified model saved to {output_path} ({size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"ONNX simplification failed: {e}")
+
+    # Dynamically quantize MatMul nodes (int8 weights)
+    try:
+        quantize_dynamic(
+            output_path,
+            quantized_path,
+            weight_type=QuantType.QInt8,
+            op_types_to_quantize=["MatMul"],
+        )
+        q_size_mb = os.path.getsize(quantized_path) / 1024**2
+        print(f"Saved quantized model to {quantized_path} ({q_size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"Quantization failed: {e}")
+
+    # Convert the full-precision model to float16
+    try:
+        fp32_model = onnx.load(output_path)
+        fp16_model = convert_float_to_float16(
+            fp32_model, keep_io_types=True, op_block_list=["MatMul"]
+        )
+        onnx.save(fp16_model, fp16_path)
+        fp16_size_mb = os.path.getsize(fp16_path) / 1024**2
+        print(f"Saved float16 model to {fp16_path} ({fp16_size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"FP16 conversion failed: {e}")
+
+    # Statically quantize weights and activations to int8
+    try:
+        dr = RandomDataReader()
+        quantize_static(
+            output_path,
+            static_quant_path,
+            dr,
+            quant_format=QuantFormat.QDQ,
+            per_channel=True,
+            weight_type=QuantType.QInt8,
+            activation_type=QuantType.QUInt8,
+        )
+        s_size_mb = os.path.getsize(static_quant_path) / 1024**2
+        print(f"Saved static int8 model to {static_quant_path} ({s_size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"Static quantization failed: {e}")
+    return None
+
+
+if __name__ == "__main__":
+    convert()


### PR DESCRIPTION
## Summary
- simplify the exported ONNX graph and add float16 and int8 variants
- add static int8 quantization using random calibration data
- expand comparison script and README with new model benchmarks

## Testing
- `python convert_to_onnx.py`
- `python compare_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1f15291a48325bde1781205dead46