### PR TITLE
Refine .NET layout SDK architecture with pipeline metrics

### DIFF
--- a/dotnet/LayoutSdk.Benchmarks/Program.cs
+++ b/dotnet/LayoutSdk.Benchmarks/Program.cs
@@ -1,25 +1,30 @@
-using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Collections.Generic;
 using System.Linq;
 using LayoutSdk;
+using LayoutSdk.Configuration;
 using SkiaSharp;
 
-static Dictionary<string,string> ParseArgs(string[] args)
+static Dictionary<string, string> ParseArgs(string[] args)
 {
-    var dict = new Dictionary<string,string>();
-    for (int i=0;i<args.Length;i++)
+    var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    for (int i = 0; i < args.Length; i++)
     {
-        var a = args[i];
-        if (a.StartsWith("--"))
+        var token = args[i];
+        if (!token.StartsWith("--", StringComparison.Ordinal))
         {
-            var key = a;
-            string val = (i+1<args.Length && !args[i+1].StartsWith("--"))? args[++i]:"true";
-            dict[key]=val;
+            continue;
         }
+
+        var key = token;
+        string value = (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+            ? args[++i]
+            : "true";
+        dict[key] = value;
     }
+
     return dict;
 }
 
@@ -28,150 +33,248 @@ static string ResizeToTemp(string path, int w, int h)
     using var bmp = SKBitmap.Decode(path);
     using var resized = bmp.Resize(new SKImageInfo(w, h), SKFilterQuality.High);
     var tmp = Path.GetTempFileName() + ".png";
-    using var img = SKImage.FromBitmap(resized);
+    using var img = SKImage.FromBitmap(resized ?? bmp);
     using var data = img.Encode(SKEncodedImageFormat.Png, 90);
     using var fs = File.OpenWrite(tmp);
     data.SaveTo(fs);
     return tmp;
 }
 
-var par = ParseArgs(args);
-if (!par.TryGetValue("--variant-name", out var variant))
+static IReadOnlyList<string> CollectImages(string directory)
 {
-    Console.Error.WriteLine("--variant-name is required");
-    return;
-}
-if (!par.TryGetValue("--engine", out var engStr))
-{
-    Console.Error.WriteLine("--engine is required");
-    return;
-}
-var engine = Enum.Parse<LayoutEngine>(engStr, true);
-string images = par.GetValueOrDefault("--images", "./dataset");
-string output = par.GetValueOrDefault("--output", "results");
-int warmup = int.Parse(par.GetValueOrDefault("--warmup", "1"));
-int runsPerImage = int.Parse(par.GetValueOrDefault("--runs-per-image", "1"));
-int targetH = int.Parse(par.GetValueOrDefault("--target-h", "640"));
-int targetW = int.Parse(par.GetValueOrDefault("--target-w", "640"));
-
-var ts = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
-var runDir = Path.Combine(output, variant, $"run-{ts}");
-Directory.CreateDirectory(runDir);
-
-var options = new LayoutSdkOptions(
-    "models/heron-optimized.onnx",
-    "models/heron-optimized.ort",
-    "models/ov-ir/heron-optimized.xml");
-using var sdk = new LayoutSdk.LayoutSdk(options);
-
-// gather image files
-var files = Directory.Exists(images)
-    ? Directory.GetFiles(images)
-        .Where(f => f.EndsWith(".jpg", true, CultureInfo.InvariantCulture) ||
-                    f.EndsWith(".jpeg", true, CultureInfo.InvariantCulture) ||
-                    f.EndsWith(".png", true, CultureInfo.InvariantCulture) ||
-                    f.EndsWith(".bmp", true, CultureInfo.InvariantCulture) ||
-                    f.EndsWith(".tif", true, CultureInfo.InvariantCulture) ||
-                    f.EndsWith(".tiff", true, CultureInfo.InvariantCulture))
-        .OrderBy(f=>f)
-        .ToList()
-    : new List<string>();
-if (files.Count==0)
-{
-    using var bmp = new SKBitmap(targetW,targetH);
-    using var img = SKImage.FromBitmap(bmp);
-    var tmp = Path.GetTempFileName()+".png";
-    using var data = img.Encode(SKEncodedImageFormat.Png, 90);
-    using var fs = File.OpenWrite(tmp);
-    data.SaveTo(fs);
-    files.Add(tmp);
-}
-
-// warmup
-var warmPath = ResizeToTemp(files[0], targetW, targetH);
-for (int i=0;i<warmup;i++)
-    sdk.Process(warmPath, false, engine);
-
-var timings = new List<double>();
-using (var csv = new StreamWriter(Path.Combine(runDir, "timings.csv")))
-{
-    csv.WriteLine("filename,ms");
-    foreach (var file in files)
+    if (!Directory.Exists(directory))
     {
-        var prepPath = ResizeToTemp(file, targetW, targetH);
-        for (int r=0;r<runsPerImage;r++)
-        {
-            var sw = Stopwatch.StartNew();
-            sdk.Process(prepPath, false, engine);
-            sw.Stop();
-            var ms = sw.Elapsed.TotalMilliseconds;
-            csv.WriteLine($"{Path.GetFileName(file)},{ms:F3}");
-            timings.Add(ms);
-        }
+        return Array.Empty<string>();
     }
+
+    return Directory.GetFiles(directory)
+        .Where(f => f.EndsWith(".jpg", true, CultureInfo.InvariantCulture)
+                 || f.EndsWith(".jpeg", true, CultureInfo.InvariantCulture)
+                 || f.EndsWith(".png", true, CultureInfo.InvariantCulture)
+                 || f.EndsWith(".bmp", true, CultureInfo.InvariantCulture)
+                 || f.EndsWith(".tif", true, CultureInfo.InvariantCulture)
+                 || f.EndsWith(".tiff", true, CultureInfo.InvariantCulture))
+        .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+        .ToList();
 }
 
-static double Percentile(List<double> seq, double p)
+static double Percentile(List<double> seq, double percentile)
 {
-    if (seq.Count==0) return double.NaN;
-    var ordered = seq.OrderBy(x=>x).ToList();
-    var idx = (int)Math.Ceiling(p/100.0*ordered.Count)-1;
-    idx = Math.Clamp(idx,0,ordered.Count-1);
-    return ordered[idx];
+    if (seq.Count == 0)
+    {
+        return double.NaN;
+    }
+
+    var ordered = seq.OrderBy(x => x).ToList();
+    var index = (int)Math.Ceiling(percentile / 100.0 * ordered.Count) - 1;
+    index = Math.Clamp(index, 0, ordered.Count - 1);
+    return ordered[index];
 }
-
-var summary = new {
-    count = timings.Count,
-    mean_ms = timings.Count>0?timings.Average():double.NaN,
-    median_ms = Percentile(timings,50),
-    p95_ms = Percentile(timings,95)
-};
-File.WriteAllText(Path.Combine(runDir,"summary.json"), JsonSerializer.Serialize(summary, new JsonSerializerOptions{WriteIndented=true}));
-
-string modelPath = engine switch {
-    LayoutEngine.Onnx => options.OnnxModelPath,
-    LayoutEngine.Ort => options.OrtModelPath,
-    LayoutEngine.Openvino => options.OpenVinoModelPath,
-    _ => ""
-};
-var modelInfo = new {
-    model_path = modelPath,
-    model_size_bytes = File.Exists(modelPath) ? new FileInfo(modelPath).Length : 0,
-    ep = "CPU",
-    device = "CPU",
-    precision = modelPath.ToLowerInvariant().Contains("fp16")?"fp16":"fp32"
-};
-File.WriteAllText(Path.Combine(runDir,"model_info.json"), JsonSerializer.Serialize(modelInfo,new JsonSerializerOptions{WriteIndented=true}));
-
-var env = new {
-    dotnet = Environment.Version.ToString(),
-    os = Environment.OSVersion.ToString()
-};
-File.WriteAllText(Path.Combine(runDir,"env.json"), JsonSerializer.Serialize(env,new JsonSerializerOptions{WriteIndented=true}));
-
-File.WriteAllText(Path.Combine(runDir,"config.json"), JsonSerializer.Serialize(new {
-    engine = engine.ToString(),
-    images,
-    variant,
-    warmup,
-    runs_per_image = runsPerImage,
-    target_h = targetH,
-    target_w = targetW
-}, new JsonSerializerOptions{WriteIndented=true}));
 
 static string Sha256Of(string path)
 {
     using var sha = SHA256.Create();
-    using var s = File.OpenRead(path);
-    return Convert.ToHexString(sha.ComputeHash(s)).ToLowerInvariant();
+    using var stream = File.OpenRead(path);
+    return Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
 }
 
-var manifest = new {
-    files = new[]{"timings.csv","summary.json","model_info.json","env.json","config.json"}
-        .Select(f=> new {file=f, sha256=Sha256Of(Path.Combine(runDir,f))})
-};
-File.WriteAllText(Path.Combine(runDir,"manifest.json"), JsonSerializer.Serialize(manifest,new JsonSerializerOptions{WriteIndented=true}));
+record BenchmarkSummary(int Count, double MeanMs, double MedianMs, double P95Ms);
 
-File.WriteAllText(Path.Combine(runDir,"logs.txt"), $"RUN {variant} ok, N={timings.Count}\n");
+record BenchmarkArtifacts(LayoutRuntime Runtime, string OutputDirectory, BenchmarkSummary Summary);
 
-Console.WriteLine($"OK: {runDir}");
+static BenchmarkArtifacts RunBenchmark(
+    LayoutRuntime runtime,
+    LayoutSdkOptions options,
+    IReadOnlyList<string> imageFiles,
+    string outputDir,
+    int warmup,
+    int runsPerImage,
+    int targetH,
+    int targetW)
+{
+    Directory.CreateDirectory(outputDir);
+
+    using var sdk = new LayoutSdk.LayoutSdk(options);
+
+    var timings = new List<double>();
+
+    var warmSource = imageFiles[0];
+    var warmResized = ResizeToTemp(warmSource, targetW, targetH);
+    for (int i = 0; i < warmup; i++)
+    {
+        sdk.Process(warmResized, overlay: false, runtime);
+    }
+
+    using (var csv = new StreamWriter(Path.Combine(outputDir, "timings.csv")))
+    {
+        csv.WriteLine("filename,ms");
+        foreach (var file in imageFiles)
+        {
+            var prepPath = ResizeToTemp(file, targetW, targetH);
+            for (int run = 0; run < runsPerImage; run++)
+            {
+                var result = sdk.Process(prepPath, overlay: false, runtime);
+                var ms = result.Metrics.TotalDuration.TotalMilliseconds;
+                csv.WriteLine($"{Path.GetFileName(file)},{ms:F3}");
+                timings.Add(ms);
+            }
+        }
+    }
+
+    var summary = new BenchmarkSummary(
+        Count: timings.Count,
+        MeanMs: timings.Count > 0 ? timings.Average() : double.NaN,
+        MedianMs: Percentile(timings, 50),
+        P95Ms: Percentile(timings, 95));
+
+    File.WriteAllText(
+        Path.Combine(outputDir, "summary.json"),
+        JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true }));
+
+    object modelInfo = runtime switch
+    {
+        LayoutRuntime.OnnxRuntime => new
+        {
+            runtime = "onnxruntime",
+            model_path = options.OnnxModelPath,
+            model_size_bytes = File.Exists(options.OnnxModelPath) ? new FileInfo(options.OnnxModelPath).Length : 0L,
+            device = "CPU",
+            precision = options.OnnxModelPath.ToLowerInvariant().Contains("fp16") ? "fp16" : "fp32"
+        },
+        LayoutRuntime.OpenVino => new
+        {
+            runtime = "openvino",
+            xml_path = options.OpenVino.ModelXmlPath,
+            xml_size_bytes = File.Exists(options.OpenVino.ModelXmlPath) ? new FileInfo(options.OpenVino.ModelXmlPath).Length : 0L,
+            bin_path = options.OpenVino.WeightsBinPath,
+            bin_size_bytes = File.Exists(options.OpenVino.WeightsBinPath) ? new FileInfo(options.OpenVino.WeightsBinPath).Length : 0L,
+            device = "CPU",
+            precision = options.OpenVino.ModelXmlPath.ToLowerInvariant().Contains("fp16") ? "fp16" : "fp32"
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
+    };
+
+    File.WriteAllText(
+        Path.Combine(outputDir, "model_info.json"),
+        JsonSerializer.Serialize(modelInfo, new JsonSerializerOptions { WriteIndented = true }));
+
+    var env = new
+    {
+        dotnet = Environment.Version.ToString(),
+        os = Environment.OSVersion.ToString()
+    };
+    File.WriteAllText(Path.Combine(outputDir, "env.json"), JsonSerializer.Serialize(env, new JsonSerializerOptions { WriteIndented = true }));
+
+    File.WriteAllText(
+        Path.Combine(outputDir, "config.json"),
+        JsonSerializer.Serialize(new
+        {
+            runtime = runtime.ToString(),
+            warmup,
+            runs_per_image = runsPerImage,
+            target_h = targetH,
+            target_w = targetW
+        }, new JsonSerializerOptions { WriteIndented = true }));
+
+    var files = new[] { "timings.csv", "summary.json", "model_info.json", "env.json", "config.json" }
+        .Select(f => new { file = f, sha256 = Sha256Of(Path.Combine(outputDir, f)) })
+        .ToList();
+
+    File.WriteAllText(
+        Path.Combine(outputDir, "manifest.json"),
+        JsonSerializer.Serialize(new { files }, new JsonSerializerOptions { WriteIndented = true }));
+
+    File.WriteAllText(Path.Combine(outputDir, "logs.txt"), $"RUN {runtime} ok, N={timings.Count}\n");
+
+    return new BenchmarkArtifacts(runtime, outputDir, summary);
+}
+
+var parameters = ParseArgs(args);
+
+if (!parameters.TryGetValue("--variant-name", out var variant))
+{
+    Console.Error.WriteLine("--variant-name is required");
+    return;
+}
+
+var compare = parameters.ContainsKey("--compare");
+LayoutRuntime[] runtimes;
+if (compare)
+{
+    runtimes = new[] { LayoutRuntime.OnnxRuntime, LayoutRuntime.OpenVino };
+}
+else if (parameters.TryGetValue("--runtime", out var runtimeValue))
+{
+    runtimes = new[] { Enum.Parse<LayoutRuntime>(runtimeValue, ignoreCase: true) };
+}
+else
+{
+    Console.Error.WriteLine("--runtime is required when --compare is not specified");
+    return;
+}
+
+var imagesDir = parameters.GetValueOrDefault("--images", "./dataset");
+var outputRoot = parameters.GetValueOrDefault("--output", "results");
+int warmup = int.Parse(parameters.GetValueOrDefault("--warmup", "1"), CultureInfo.InvariantCulture);
+int runsPerImage = int.Parse(parameters.GetValueOrDefault("--runs-per-image", "1"), CultureInfo.InvariantCulture);
+int targetH = int.Parse(parameters.GetValueOrDefault("--target-h", "640"), CultureInfo.InvariantCulture);
+int targetW = int.Parse(parameters.GetValueOrDefault("--target-w", "640"), CultureInfo.InvariantCulture);
+
+var images = CollectImages(imagesDir).ToList();
+if (images.Count == 0)
+{
+    using var bmp = new SKBitmap(targetW, targetH);
+    using var img = SKImage.FromBitmap(bmp);
+    var tmp = Path.GetTempFileName() + ".png";
+    using var data = img.Encode(SKEncodedImageFormat.Png, 90);
+    using var fs = File.OpenWrite(tmp);
+    data.SaveTo(fs);
+    images.Add(tmp);
+}
+
+if (compare && images.Count > 2)
+{
+    images = images.Take(2).ToList();
+}
+
+var onnxModelPath = parameters.GetValueOrDefault("--onnx-model", "models/heron-optimized.onnx");
+var openVinoXml = parameters.GetValueOrDefault("--openvino-xml", "models/ov-ir/heron-optimized.xml");
+parameters.TryGetValue("--openvino-bin", out var openVinoBin);
+var openVinoOptions = string.IsNullOrWhiteSpace(openVinoBin)
+    ? new OpenVinoModelOptions(openVinoXml)
+    : new OpenVinoModelOptions(openVinoXml, openVinoBin);
+
+var options = new LayoutSdkOptions(
+    onnxModelPath,
+    openVinoOptions,
+    defaultLanguage: DocumentLanguage.English,
+    validateModelPaths: parameters.ContainsKey("--validate-models"));
+
+var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+var runDirectory = Path.Combine(outputRoot, variant, $"run-{timestamp}");
+Directory.CreateDirectory(runDirectory);
+
+var artifacts = new List<BenchmarkArtifacts>();
+foreach (var runtime in runtimes)
+{
+    var runtimeDir = compare
+        ? Path.Combine(runDirectory, runtime.ToString().ToLowerInvariant())
+        : runDirectory;
+    artifacts.Add(RunBenchmark(runtime, options, images, runtimeDir, warmup, runsPerImage, targetH, targetW));
+}
+
+if (compare)
+{
+    var payload = artifacts.Select(a => new
+    {
+        runtime = a.Runtime.ToString(),
+        summary = a.Summary,
+        output_directory = Path.GetRelativePath(runDirectory, a.OutputDirectory)
+    });
+
+    File.WriteAllText(
+        Path.Combine(runDirectory, "comparison.json"),
+        JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+}
+
+Console.WriteLine($"OK: {runDirectory}");

--- a/dotnet/LayoutSdk.Tests/LayoutSdkTests.cs
+++ b/dotnet/LayoutSdk.Tests/LayoutSdkTests.cs
@@ -1,39 +1,53 @@
 using LayoutSdk;
+using LayoutSdk.Configuration;
+using LayoutSdk.Factories;
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
+using LayoutSdk.Inference;
+using LayoutSdk.Metrics;
+using LayoutSdk.Processing;
 using SkiaSharp;
 
 namespace LayoutSdk.Tests;
 
 file class FakeBackend : ILayoutBackend
 {
-    public IReadOnlyList<BoundingBox> Infer(SKBitmap image) =>
-        new List<BoundingBox> { new(1, 1, 2, 2, "box") };
+    public LayoutBackendResult Infer(ImageTensor tensor) =>
+        new(new List<BoundingBox> { new(1, 1, 2, 2, "box") });
+}
+
+file class FakeBackendFactory : ILayoutBackendFactory
+{
+    private readonly ILayoutBackend _backend = new FakeBackend();
+
+    public ILayoutBackend Create(LayoutRuntime runtime) => _backend;
 }
 
 public class LayoutSdkTests
 {
     private static LayoutSdk CreateSdkWithFakeBackend()
     {
-        var sdk = new LayoutSdk(new LayoutSdkOptions("", "", ""));
-        sdk.Backends[LayoutEngine.Onnx] = new FakeBackend();
-        return sdk;
+        var options = new LayoutSdkOptions(
+            "onnx-path",
+            new OpenVinoModelOptions("xml-path", "bin-path"),
+            DocumentLanguage.Italian);
+        return new LayoutSdk(options, new FakeBackendFactory());
     }
 
     [Fact]
     public void Process_EmptyPath_Throws()
     {
         var sdk = CreateSdkWithFakeBackend();
-        Assert.Throws<ArgumentException>(() => sdk.Process("", false, LayoutEngine.Onnx));
+        Assert.Throws<ArgumentException>(() => sdk.Process("", false, LayoutRuntime.OnnxRuntime));
     }
 
     [Fact]
     public void Process_MissingImage_Throws()
     {
         var sdk = CreateSdkWithFakeBackend();
-        Assert.Throws<FileNotFoundException>(() => sdk.Process("missing.png", false, LayoutEngine.Onnx));
+        Assert.Throws<FileNotFoundException>(() => sdk.Process("missing.png", false, LayoutRuntime.OnnxRuntime));
     }
 
     private static string SampleImage =>
@@ -43,16 +57,62 @@ public class LayoutSdkTests
     public void Process_Overlay_ReturnsBitmap()
     {
         var sdk = CreateSdkWithFakeBackend();
-        var result = sdk.Process(SampleImage, true, LayoutEngine.Onnx);
+        var result = sdk.Process(SampleImage, true, LayoutRuntime.OnnxRuntime);
         Assert.NotNull(result.OverlayImage);
         Assert.Single(result.Boxes);
+        Assert.Equal(DocumentLanguage.Italian, result.Language);
+        Assert.True(result.Metrics.OverlayDuration >= TimeSpan.Zero);
+        Assert.True(result.Metrics.PreprocessDuration >= TimeSpan.Zero);
+        Assert.True(result.Metrics.InferenceDuration >= TimeSpan.Zero);
+        Assert.Equal(result.Metrics.PreprocessDuration + result.Metrics.InferenceDuration + result.Metrics.OverlayDuration, result.Metrics.TotalDuration);
     }
 
     [Fact]
     public void Process_NoOverlay_ReturnsNull()
     {
         var sdk = CreateSdkWithFakeBackend();
-        var result = sdk.Process(SampleImage, false, LayoutEngine.Onnx);
+        var result = sdk.Process(SampleImage, false, LayoutRuntime.OnnxRuntime);
         Assert.Null(result.OverlayImage);
+        Assert.Equal(TimeSpan.Zero, result.Metrics.OverlayDuration);
     }
+
+    [Fact]
+    public void OptionsEnsureModelPathsThrowsWhenMissing()
+    {
+        var options = new LayoutSdkOptions(
+            "missing",
+            new OpenVinoModelOptions("missing.xml", "missing.bin"),
+            validateModelPaths: true);
+        Assert.Throws<FileNotFoundException>(() => options.EnsureModelPaths());
+    }
+
+    [Fact]
+    public void OptionsEnsureModelPathsSucceedsWhenFilesExist()
+    {
+        var onnx = Path.GetTempFileName();
+        var xml = Path.GetTempFileName();
+        var bin = Path.GetTempFileName();
+        try
+        {
+            var options = new LayoutSdkOptions(
+                onnx,
+                new OpenVinoModelOptions(xml, bin),
+                DocumentLanguage.English,
+                validateModelPaths: true);
+            options.EnsureModelPaths();
+        }
+        finally
+        {
+            File.Delete(onnx);
+            File.Delete(xml);
+            File.Delete(bin);
+        }
+    }
+
+    [Fact]
+    public void OpenVinoModelOptionsInfersBinPathWhenMissing()
+    {
+        var options = new OpenVinoModelOptions("/tmp/model.xml");
+        Assert.Equal(Path.ChangeExtension("/tmp/model.xml", ".bin"), options.WeightsBinPath);
+}
 }

--- a/dotnet/LayoutSdk/Configuration/DocumentLanguage.cs
+++ b/dotnet/LayoutSdk/Configuration/DocumentLanguage.cs
@@ -1,0 +1,10 @@
+namespace LayoutSdk.Configuration;
+
+public enum DocumentLanguage
+{
+    English,
+    French,
+    German,
+    Italian,
+    Spanish
+}

--- a/dotnet/LayoutSdk/Configuration/LayoutSdkOptions.cs
+++ b/dotnet/LayoutSdk/Configuration/LayoutSdkOptions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace LayoutSdk.Configuration;
+
+public sealed class LayoutSdkOptions
+{
+    public LayoutSdkOptions(
+        string onnxModelPath,
+        OpenVinoModelOptions openVino,
+        DocumentLanguage defaultLanguage = DocumentLanguage.English,
+        bool validateModelPaths = false)
+    {
+        if (string.IsNullOrWhiteSpace(onnxModelPath))
+        {
+            throw new ArgumentException("ONNX model path must be provided", nameof(onnxModelPath));
+        }
+
+        OnnxModelPath = onnxModelPath;
+        OpenVino = openVino ?? throw new ArgumentNullException(nameof(openVino));
+        DefaultLanguage = defaultLanguage;
+        ValidateModelPaths = validateModelPaths;
+    }
+
+    public string OnnxModelPath { get; }
+
+    public OpenVinoModelOptions OpenVino { get; }
+
+    public DocumentLanguage DefaultLanguage { get; }
+
+    public bool ValidateModelPaths { get; }
+
+    public void EnsureModelPaths()
+    {
+        if (!ValidateModelPaths)
+        {
+            return;
+        }
+
+        ValidatePath(OnnxModelPath, nameof(OnnxModelPath));
+        OpenVino.EnsureFilesExist();
+    }
+
+    private static void ValidatePath(string? path, string argumentName)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            throw new FileNotFoundException($"Model file not found for {argumentName}", path);
+        }
+    }
+}

--- a/dotnet/LayoutSdk/Configuration/OpenVinoModelOptions.cs
+++ b/dotnet/LayoutSdk/Configuration/OpenVinoModelOptions.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+
+namespace LayoutSdk.Configuration;
+
+public sealed class OpenVinoModelOptions
+{
+    public OpenVinoModelOptions(string modelXmlPath, string? weightsBinPath = null)
+    {
+        if (string.IsNullOrWhiteSpace(modelXmlPath))
+        {
+            throw new ArgumentException("Model XML path must be provided", nameof(modelXmlPath));
+        }
+
+        ModelXmlPath = modelXmlPath;
+        WeightsBinPath = !string.IsNullOrWhiteSpace(weightsBinPath)
+            ? weightsBinPath!
+            : InferWeightsPath(modelXmlPath);
+    }
+
+    public string ModelXmlPath { get; }
+
+    public string WeightsBinPath { get; }
+
+    public void EnsureFilesExist()
+    {
+        ValidatePath(ModelXmlPath, nameof(ModelXmlPath));
+        ValidatePath(WeightsBinPath, nameof(WeightsBinPath));
+    }
+
+    private static string InferWeightsPath(string xmlPath)
+    {
+        var binPath = Path.ChangeExtension(xmlPath, ".bin");
+        if (string.IsNullOrWhiteSpace(binPath))
+        {
+            throw new InvalidOperationException("Unable to infer OpenVINO weights path from XML path.");
+        }
+
+        return binPath;
+    }
+
+    private static void ValidatePath(string path, string argumentName)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            throw new FileNotFoundException($"Model file not found for {argumentName}", path);
+        }
+    }
+}

--- a/dotnet/LayoutSdk/Factories/ILayoutBackendFactory.cs
+++ b/dotnet/LayoutSdk/Factories/ILayoutBackendFactory.cs
@@ -1,0 +1,6 @@
+namespace LayoutSdk.Factories;
+
+public interface ILayoutBackendFactory
+{
+    ILayoutBackend Create(LayoutRuntime runtime);
+}

--- a/dotnet/LayoutSdk/Factories/LayoutBackendFactory.cs
+++ b/dotnet/LayoutSdk/Factories/LayoutBackendFactory.cs
@@ -1,0 +1,24 @@
+using System;
+using LayoutSdk.Configuration;
+
+namespace LayoutSdk.Factories;
+
+public sealed class LayoutBackendFactory : ILayoutBackendFactory
+{
+    private readonly LayoutSdkOptions _options;
+
+    public LayoutBackendFactory(LayoutSdkOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.EnsureModelPaths();
+    }
+
+    public ILayoutBackend Create(LayoutRuntime runtime) => runtime switch
+    {
+        LayoutRuntime.OnnxRuntime => new OnnxRuntimeBackend(_options.OnnxModelPath),
+        LayoutRuntime.OpenVino => new OpenVinoBackend(
+            _options.OpenVino.ModelXmlPath,
+            _options.OpenVino.WeightsBinPath),
+        _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
+    };
+}

--- a/dotnet/LayoutSdk/ILayoutBackend.cs
+++ b/dotnet/LayoutSdk/ILayoutBackend.cs
@@ -1,9 +1,9 @@
-using SkiaSharp;
-using System.Collections.Generic;
+using LayoutSdk.Inference;
+using LayoutSdk.Processing;
 
 namespace LayoutSdk;
 
-internal interface ILayoutBackend
+public interface ILayoutBackend
 {
-    IReadOnlyList<BoundingBox> Infer(SKBitmap image);
+    LayoutBackendResult Infer(ImageTensor tensor);
 }

--- a/dotnet/LayoutSdk/Inference/LayoutBackendResult.cs
+++ b/dotnet/LayoutSdk/Inference/LayoutBackendResult.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace LayoutSdk.Inference;
+
+public sealed record LayoutBackendResult(IReadOnlyList<BoundingBox> Boxes);

--- a/dotnet/LayoutSdk/LayoutDefaults.cs
+++ b/dotnet/LayoutSdk/LayoutDefaults.cs
@@ -1,0 +1,13 @@
+using SkiaSharp;
+
+namespace LayoutSdk;
+
+internal static class LayoutDefaults
+{
+    public const float OverlayStrokeWidth = 2f;
+    public static readonly SKColor OverlayColor = SKColors.Lime;
+
+    public const string EmptyImagePathMessage = "Image path is empty";
+    public const string ImageNotFoundMessage = "Image not found";
+    public const string ImageDecodeFailureMessage = "Unable to decode image";
+}

--- a/dotnet/LayoutSdk/LayoutEngine.cs
+++ b/dotnet/LayoutSdk/LayoutEngine.cs
@@ -1,8 +1,0 @@
-namespace LayoutSdk;
-
-public enum LayoutEngine
-{
-    Onnx,
-    Ort,
-    Openvino
-}

--- a/dotnet/LayoutSdk/LayoutResult.cs
+++ b/dotnet/LayoutSdk/LayoutResult.cs
@@ -1,3 +1,5 @@
+using LayoutSdk.Configuration;
+using LayoutSdk.Metrics;
 using SkiaSharp;
 using System.Collections.Generic;
 
@@ -7,12 +9,23 @@ public record BoundingBox(float X, float Y, float Width, float Height, string La
 
 public class LayoutResult
 {
-    public IReadOnlyList<BoundingBox> Boxes { get; }
-    public SKBitmap? OverlayImage { get; }
-
-    public LayoutResult(IReadOnlyList<BoundingBox> boxes, SKBitmap? overlay)
+    public LayoutResult(
+        IReadOnlyList<BoundingBox> boxes,
+        SKBitmap? overlay,
+        DocumentLanguage language,
+        LayoutExecutionMetrics metrics)
     {
         Boxes = boxes;
         OverlayImage = overlay;
+        Language = language;
+        Metrics = metrics;
     }
+
+    public IReadOnlyList<BoundingBox> Boxes { get; }
+
+    public SKBitmap? OverlayImage { get; }
+
+    public DocumentLanguage Language { get; }
+
+    public LayoutExecutionMetrics Metrics { get; }
 }

--- a/dotnet/LayoutSdk/LayoutRuntime.cs
+++ b/dotnet/LayoutSdk/LayoutRuntime.cs
@@ -1,0 +1,8 @@
+namespace LayoutSdk;
+
+public enum LayoutRuntime
+{
+    OnnxRuntime,
+    OpenVino
+}
+

--- a/dotnet/LayoutSdk/Metrics/LayoutExecutionMetrics.cs
+++ b/dotnet/LayoutSdk/Metrics/LayoutExecutionMetrics.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace LayoutSdk.Metrics;
+
+public readonly record struct LayoutExecutionMetrics(
+    TimeSpan PreprocessDuration,
+    TimeSpan InferenceDuration,
+    TimeSpan OverlayDuration)
+{
+    public TimeSpan TotalDuration => PreprocessDuration + InferenceDuration + OverlayDuration;
+}

--- a/dotnet/LayoutSdk/OpenVinoBackend.cs
+++ b/dotnet/LayoutSdk/OpenVinoBackend.cs
@@ -1,9 +1,10 @@
 using OpenVinoSharp;
-using SkiaSharp;
 using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using LayoutSdk.Inference;
+using LayoutSdk.Processing;
 
 namespace LayoutSdk;
 
@@ -15,58 +16,33 @@ internal sealed class OpenVinoBackend : ILayoutBackend, IDisposable
     private readonly InferRequest _request;
     private readonly string _inputName;
 
-    public OpenVinoBackend(string modelPath)
+    public OpenVinoBackend(string modelXmlPath, string weightsBinPath)
     {
-        // copy OpenVINO native libraries next to the executable so P/Invoke can resolve them
-        var nuget = Environment.GetEnvironmentVariable("NUGET_PACKAGES")
-                   ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
-        var runtimes = Path.Combine(nuget, "openvino.runtime.ubuntu.24-x86_64");
-        if (Directory.Exists(runtimes))
+        if (string.IsNullOrWhiteSpace(modelXmlPath))
         {
-            var latest = Directory.GetDirectories(runtimes).OrderByDescending(p => p).FirstOrDefault();
-            if (latest != null)
-            {
-                var native = Path.Combine(latest, "runtimes", "ubuntu.24-x86_64", "native");
-                var execDir = AppContext.BaseDirectory;
-                foreach (var src in Directory.GetFiles(native))
-                {
-                    var dest = Path.Combine(execDir, Path.GetFileName(src));
-                    if (!File.Exists(dest))
-                    {
-                        File.Copy(src, dest);
-                    }
-                    try { System.Runtime.InteropServices.NativeLibrary.Load(dest); } catch { }
-                }
-            }
+            throw new ArgumentException("Model XML path must be provided", nameof(modelXmlPath));
         }
 
+        if (string.IsNullOrWhiteSpace(weightsBinPath))
+        {
+            throw new ArgumentException("Weights BIN path must be provided", nameof(weightsBinPath));
+        }
+
+        CopyNativeBinariesNearExecutable();
+
         _core = new Core();
-        _model = _core.read_model(modelPath);
+        _model = _core.read_model(modelXmlPath, weightsBinPath);
         _compiled = _core.compile_model(_model, "CPU");
         _request = _compiled.create_infer_request();
         _inputName = _model.inputs()[0].get_any_name();
     }
 
-    public IReadOnlyList<BoundingBox> Infer(SKBitmap image)
+    public LayoutBackendResult Infer(ImageTensor tensor)
     {
-        int w = image.Width;
-        int h = image.Height;
-        float[] data = new float[1 * 3 * h * w];
-        for (int y = 0; y < h; y++)
-        {
-            for (int x = 0; x < w; x++)
-            {
-                var c = image.GetPixel(x, y);
-                int idx = y * w + x;
-                data[idx] = c.Red / 255f;
-                data[idx + h * w] = c.Green / 255f;
-                data[idx + 2 * h * w] = c.Blue / 255f;
-            }
-        }
-        using var tensor = new Tensor(new Shape(new long[] { 1, 3, h, w }), data);
-        _request.set_tensor(_inputName, tensor);
+        using var inputTensor = new Tensor(new Shape(new long[] { 1, tensor.Channels, tensor.Height, tensor.Width }), tensor.Buffer);
+        _request.set_tensor(_inputName, inputTensor);
         _request.infer();
-        return new List<BoundingBox>();
+        return new LayoutBackendResult(new List<BoundingBox>());
     }
 
     public void Dispose()
@@ -75,5 +51,46 @@ internal sealed class OpenVinoBackend : ILayoutBackend, IDisposable
         _compiled.Dispose();
         _model.Dispose();
         _core.Dispose();
+    }
+
+    private static void CopyNativeBinariesNearExecutable()
+    {
+        var nuget = Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+                   ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+        var runtimes = Path.Combine(nuget, "openvino.runtime.ubuntu.24-x86_64");
+        if (!Directory.Exists(runtimes))
+        {
+            return;
+        }
+
+        var latest = Directory.GetDirectories(runtimes).OrderByDescending(p => p).FirstOrDefault();
+        if (latest == null)
+        {
+            return;
+        }
+
+        var native = Path.Combine(latest, "runtimes", "ubuntu.24-x86_64", "native");
+        if (!Directory.Exists(native))
+        {
+            return;
+        }
+
+        var execDir = AppContext.BaseDirectory;
+        foreach (var src in Directory.GetFiles(native))
+        {
+            var dest = Path.Combine(execDir, Path.GetFileName(src));
+            if (!File.Exists(dest))
+            {
+                File.Copy(src, dest);
+            }
+
+            try
+            {
+                System.Runtime.InteropServices.NativeLibrary.Load(dest);
+            }
+            catch
+            {
+            }
+        }
     }
 }

--- a/dotnet/LayoutSdk/Processing/IImagePreprocessor.cs
+++ b/dotnet/LayoutSdk/Processing/IImagePreprocessor.cs
@@ -1,0 +1,8 @@
+using SkiaSharp;
+
+namespace LayoutSdk.Processing;
+
+public interface IImagePreprocessor
+{
+    ImageTensor Preprocess(SKBitmap image);
+}

--- a/dotnet/LayoutSdk/Processing/ImageTensor.cs
+++ b/dotnet/LayoutSdk/Processing/ImageTensor.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Buffers;
+
+namespace LayoutSdk.Processing;
+
+public sealed class ImageTensor : IDisposable
+{
+    private readonly float[] _buffer;
+    private bool _disposed;
+
+    private ImageTensor(float[] buffer, int width, int height, int channels)
+    {
+        _buffer = buffer;
+        Width = width;
+        Height = height;
+        Channels = channels;
+        Length = width * height * channels;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public int Channels { get; }
+
+    public int Length { get; }
+
+    public static ImageTensor Rent(int width, int height, int channels)
+    {
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width));
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height));
+        }
+
+        if (channels <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channels));
+        }
+
+        var required = checked(width * height * channels);
+        var buffer = ArrayPool<float>.Shared.Rent(required);
+        Array.Clear(buffer, 0, required);
+        return new ImageTensor(buffer, width, height, channels);
+    }
+
+    public Span<float> AsSpan() => _buffer.AsSpan(0, Length);
+
+    public float[] Buffer => _buffer;
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        ArrayPool<float>.Shared.Return(_buffer);
+        _disposed = true;
+    }
+}

--- a/dotnet/LayoutSdk/Processing/LayoutPipeline.cs
+++ b/dotnet/LayoutSdk/Processing/LayoutPipeline.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics;
+using LayoutSdk.Inference;
+using LayoutSdk.Metrics;
+using SkiaSharp;
+
+namespace LayoutSdk.Processing;
+
+internal sealed class LayoutPipeline : IDisposable
+{
+    private readonly ILayoutBackend _backend;
+    private readonly IImagePreprocessor _preprocessor;
+    private bool _disposed;
+
+    public LayoutPipeline(ILayoutBackend backend, IImagePreprocessor preprocessor)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _preprocessor = preprocessor ?? throw new ArgumentNullException(nameof(preprocessor));
+    }
+
+    public LayoutPipelineResult Execute(SKBitmap image)
+    {
+        if (image is null)
+        {
+            throw new ArgumentNullException(nameof(image));
+        }
+
+        var preprocessWatch = Stopwatch.StartNew();
+        using var tensor = _preprocessor.Preprocess(image);
+        preprocessWatch.Stop();
+
+        var inferenceWatch = Stopwatch.StartNew();
+        var backendResult = _backend.Infer(tensor);
+        inferenceWatch.Stop();
+
+        var metrics = new LayoutExecutionMetrics(
+            PreprocessDuration: preprocessWatch.Elapsed,
+            InferenceDuration: inferenceWatch.Elapsed,
+            OverlayDuration: TimeSpan.Zero);
+
+        return new LayoutPipelineResult(backendResult.Boxes, metrics);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_backend is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        _disposed = true;
+    }
+}

--- a/dotnet/LayoutSdk/Processing/LayoutPipelineResult.cs
+++ b/dotnet/LayoutSdk/Processing/LayoutPipelineResult.cs
@@ -1,0 +1,6 @@
+using System.Collections.Generic;
+using LayoutSdk.Metrics;
+
+namespace LayoutSdk.Processing;
+
+internal sealed record LayoutPipelineResult(IReadOnlyList<BoundingBox> Boxes, LayoutExecutionMetrics Metrics);

--- a/dotnet/LayoutSdk/Processing/SkiaImagePreprocessor.cs
+++ b/dotnet/LayoutSdk/Processing/SkiaImagePreprocessor.cs
@@ -1,0 +1,32 @@
+using SkiaSharp;
+using System;
+
+namespace LayoutSdk.Processing;
+
+public sealed class SkiaImagePreprocessor : IImagePreprocessor
+{
+    private const int Channels = 3;
+
+    public ImageTensor Preprocess(SKBitmap image)
+    {
+        if (image is null)
+        {
+            throw new ArgumentNullException(nameof(image));
+        }
+
+        var tensor = ImageTensor.Rent(image.Width, image.Height, Channels);
+        var span = tensor.AsSpan();
+        var plane = image.Width * image.Height;
+
+        var pixels = image.Pixels;
+        for (var i = 0; i < plane; i++)
+        {
+            var color = pixels[i];
+            span[i] = color.Red / 255f;
+            span[i + plane] = color.Green / 255f;
+            span[i + 2 * plane] = color.Blue / 255f;
+        }
+
+        return tensor;
+    }
+}

--- a/dotnet/LayoutSdk/Rendering/IImageOverlayRenderer.cs
+++ b/dotnet/LayoutSdk/Rendering/IImageOverlayRenderer.cs
@@ -1,0 +1,9 @@
+using SkiaSharp;
+using System.Collections.Generic;
+
+namespace LayoutSdk.Rendering;
+
+public interface IImageOverlayRenderer
+{
+    SKBitmap CreateOverlay(SKBitmap baseImage, IReadOnlyList<BoundingBox> boxes);
+}

--- a/dotnet/LayoutSdk/Rendering/ImageOverlayRenderer.cs
+++ b/dotnet/LayoutSdk/Rendering/ImageOverlayRenderer.cs
@@ -1,0 +1,37 @@
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+
+namespace LayoutSdk.Rendering;
+
+internal sealed class ImageOverlayRenderer : IImageOverlayRenderer
+{
+    public SKBitmap CreateOverlay(SKBitmap baseImage, IReadOnlyList<BoundingBox> boxes)
+    {
+        if (baseImage == null)
+        {
+            throw new ArgumentNullException(nameof(baseImage));
+        }
+
+        if (boxes == null)
+        {
+            throw new ArgumentNullException(nameof(boxes));
+        }
+
+        var copy = baseImage.Copy();
+        using var canvas = new SKCanvas(copy);
+        using var paint = new SKPaint
+        {
+            Color = LayoutDefaults.OverlayColor,
+            IsStroke = true,
+            StrokeWidth = LayoutDefaults.OverlayStrokeWidth
+        };
+
+        foreach (var box in boxes)
+        {
+            canvas.DrawRect(box.X, box.Y, box.Width, box.Height, paint);
+        }
+
+        return copy;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `LayoutRuntime` enum together with `OpenVinoModelOptions` so the .NET SDK can switch between ONNX Runtime and native OpenVINO IR backends
- update the benchmarking console to support a `--compare` mode that times both runtimes on the first two dataset pages while persisting aligned metadata
- refresh documentation and unit tests to cover the new runtime selection workflow, native model requirements, and validation helpers
- refactor the .NET SDK into modular preprocessing, backend, and metrics components with injectable factories so enterprise hosts can reuse the new `ImageTensor`, `IImagePreprocessor`, and `LayoutExecutionMetrics` building blocks for high-performance pipelines
- document the new architecture, metric-driven benchmarks, and dependency versions in the README to guide professional adoption

## Testing
- `dotnet test dotnet/LayoutSdk.Tests/LayoutSdk.Tests.csproj` *(fails: Microsoft.NETCore.App 8.0 runtime not installed in container; see CLI output)*

------
https://chatgpt.com/codex/tasks/task_e_68ce34573a088325b04175373f48afbb